### PR TITLE
Make random number spec more liberal

### DIFF
--- a/spec/features/calculations_spec.rb
+++ b/spec/features/calculations_spec.rb
@@ -461,8 +461,9 @@ describe "/random/new" do
       fill_in "Minimum", with: 1.0
       fill_in "Maximum", with: 10.0
       click_button "Pick random number"
-      page.all("dd").each do |el|
-        num = el.text.to_f
+      # Array containing each number rendered on the random/results page
+      numbers_on_page = page.text.scan(/\d+\.\d*/).map(&:to_f)
+      numbers_on_page.each do |num|
         if num != 1 && num != 10
           random_numbers.push(num)
         end


### PR DESCRIPTION
Currently the "/random/new outputs a random number" test will only pass when the `Minimum`, `Maximum`, and `Random` numbers are wrapped in `<dd></dd>` tags. While this does match the target it also follows stricter guidelines than other tests that check _content_ rather than the _structure_.

This branch changes:
* Specs that search `<dd></dd>` tags now scan the page text with a regular expression.

I didn't add test data because this is an assignment but you can check with my solutions workspace [here](https://ide.c9.io/jmw686/omnicalc-params).